### PR TITLE
fix: checks for 'document' to fix from breaking node.js

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -122,8 +122,9 @@ forward({
 
 $logs.on(createRecordFx.doneData, (logs, record) => [record, ...logs]);
 
-export function createInspector(options: Options = {}): Inspector {
-  const root = document.createElement('div');
+export function createInspector(options: Options = {}): Inspector | undefined {
+  const root = typeof document === 'object' && document.createElement('div');
+  if (!root) return undefined;
   root.classList.add('effector-inspector');
 
   document.body.append(root);

--- a/src/view.ts
+++ b/src/view.ts
@@ -14,7 +14,7 @@ const $isVisible = createStore(false);
 const togglePressed = createEvent();
 const showInspector = createEvent();
 
-document.addEventListener('keypress', (event) => {
+typeof document === 'object' && document.addEventListener('keypress', (event) => {
   if (event.keyCode === KEY_B && event.ctrlKey) {
     togglePressed();
   }


### PR DESCRIPTION
effector-logger/attach imports effector-inspector as a module and these doment declarations crushing
the app in the SSR case

effector-logger issue #28